### PR TITLE
Add worker/clustering support for Bun runtime

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,14 @@ export class Jetpath {
       & Record<string, any>;
   }
   async listen(): Promise<void> {
+    this.server = server(this.plugs, this.options);
+    if (this.server.isPrimary) {
+      this.server.listen(this.options.port);
+      this.listening = true;
+      this._nativeServer = this.server;
+      return;
+    }
+
     // ? {-view-} here is replaced at build time to html
     const UI = await readFile(html_path, {
       encoding: "utf-8",
@@ -188,9 +196,7 @@ export class Jetpath {
 
     //
     assignMiddleware(_JetPath_paths, _jet_middleware);
-    // ? start server
-    // ? check if server is already listening
-    this.server = server(this.plugs, this.options);
+
     // ? add plugins to the server
     if (
       this.server.edge &&

--- a/src/primitives/functions.ts
+++ b/src/primitives/functions.ts
@@ -73,7 +73,13 @@ export const _jet_middleware: Record<
 export const server = (
   plugs: JetPlugin[],
   options: jetOptions,
-): { listen: any; edge: boolean } => {
+): {
+  listen: any;
+  edge: boolean;
+  isPrimary?: boolean;
+  stop?: () => void;
+  close?: (cb?: () => void) => void;
+} => {
   let server;
   let server_else;
   const runtimeConfig = options.runtimes;
@@ -144,6 +150,40 @@ export const server = (
     };
   }
   if (runtime["bun"]) {
+    const clusterConfig = runtimeConfig?.bun?.cluster;
+    if (clusterConfig) {
+      const cluster = require("node:cluster");
+      const os = require("node:os");
+
+      if (cluster.isPrimary) {
+        const numWorkers = typeof clusterConfig === "number"
+          ? clusterConfig
+          : os.cpus().length;
+
+        server = {
+          listen(port: number) {
+            LOG.log(`Primary ${process.pid} is starting ${numWorkers} workers`, "info");
+            for (let i = 0; i < numWorkers; i++) {
+              cluster.fork();
+            }
+
+            cluster.on("exit", (worker: any) => {
+              LOG.log(`worker ${worker.process.pid} died, restarting...`, "warn");
+              cluster.fork();
+            });
+          },
+          stop() {
+            for (const id in cluster.workers) {
+              cluster.workers[id].kill();
+            }
+          },
+          edge: false,
+          isPrimary: true,
+        };
+        return server;
+      }
+    }
+
     if (options.upgrade && options.upgrade === true) {
       server = {
         listen(port: number) {

--- a/src/primitives/types.ts
+++ b/src/primitives/types.ts
@@ -197,6 +197,7 @@ export type jetOptions = {
   runtimes?: {
     bun?: {
       reusePort?: boolean;
+      cluster?: boolean | number;
     };
     deno?: {};
     node?: {};


### PR DESCRIPTION
This PR introduces native worker/clustering support for the Bun.js runtime within the Jetpath framework.

### Key Changes:
- **Configuration:** Users can now enable clustering by setting `runtimes.bun.cluster` in the `Jetpath` options. It accepts a boolean (to use all CPUs) or a specific number of workers.
- **Primary/Worker Logic:** When clustering is enabled on Bun, the primary process takes on the role of a process manager, forking the requested number of workers and monitoring their health. If a worker dies, it is automatically restarted to maintain service availability.
- **Optimized Startup:** The `listen()` method has been refactored to initialize the server early. In the primary process, it starts the cluster and exits the setup flow, avoiding unnecessary work like route scanning or UI generation. Worker processes proceed with the full initialization before serving requests.
- **Port Sharing:** Leverages Bun's built-in support for `node:cluster`, which handles transparent port sharing among workers.

This addition enhances Jetpath's performance on multi-core systems when running on Bun, while maintaining its zero-config, runtime-agnostic philosophy.

---
*PR created automatically by Jules for task [16655505401955298210](https://jules.google.com/task/16655505401955298210) started by @FridayCandour*

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added clustering support for Bun runtime, enabling primary process to fork multiple worker processes for improved scalability.</li>
<li>Modified the server function return type to include isPrimary, stop, and close properties.</li>
<li>Updated jetOptions type to support cluster configuration as boolean or number for Bun.</li>
<li>Relocated server creation in the listen method and added handling for primary server instances.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clustering support for Bun servers, enabling improved performance and resource utilization across multiple processes.
  * New cluster configuration option available in Bun runtime settings, allowing you to specify the number of worker processes (defaults to CPU count).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->